### PR TITLE
Use generics in concgroup

### DIFF
--- a/concgroup/concgroup_test.go
+++ b/concgroup/concgroup_test.go
@@ -1,0 +1,42 @@
+package concgroup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcGroup(t *testing.T) {
+	results := make([]string, 0)
+
+	cg := WithOptions(context.Background(), 1, func(identifier string, obj string, err error) {
+		results = append(results, identifier)
+	})
+
+	cg.Go("foo", func() (string, error) { return "foo", nil })
+	cg.Go("bar", func() (string, error) { return "bar", nil })
+
+	cg.Wait()
+
+	require.Contains(t, results, "foo")
+}
+
+func TestConcurrencyLimit(t *testing.T) {
+	results := make([]string, 0)
+
+	cg := WithOptions(context.Background(), 1, func(identifier string, obj string, err error) {
+		results = append(results, identifier)
+	})
+
+	cg.Go("foo", func() (string, error) {
+		time.Sleep(1 * time.Second)
+		return "foo", nil
+	})
+	// Go blocks on concurrency limit, so lets put it in a goroutine
+	// so we can validate that the limit is respected
+	go cg.Go("bar", func() (string, error) { return "bar", nil })
+	time.Sleep(10 * time.Millisecond)
+	require.Empty(t, results)
+}

--- a/concgroup/go.mod
+++ b/concgroup/go.mod
@@ -1,3 +1,11 @@
 module concgroup
 
 go 1.22.2
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/concgroup/go.sum
+++ b/concgroup/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sample/main.go
+++ b/sample/main.go
@@ -33,7 +33,7 @@ func send(identifier string, data interface{}, err error) {
 func main() {
 	limit := 3
 	bazId := 0
-	cg, _ := concgroup.WithOptions(context.Background(), limit, func(identifier string, data interface{}, err error) {
+	cg := concgroup.WithOptions(context.Background(), limit, func(identifier string, data interface{}, err error) {
 		send(identifier, data, err)
 	})
 

--- a/server/main.go
+++ b/server/main.go
@@ -22,7 +22,7 @@ func main() {
 	r.Get("/foobars", func(w http.ResponseWriter, r *http.Request) {
 		cw := NewChunkedWriter(w)
 
-		cg, _ := concgroup.WithOptions(context.Background(), MAX_CONCURRENCY, func(identifier string, obj interface{}, err error) {
+		cg := concgroup.WithOptions(context.Background(), MAX_CONCURRENCY, func(identifier string, obj interface{}, err error) {
 			cw.Send(NewChunk(identifier, obj, err))
 		})
 


### PR DESCRIPTION
This updates the concgroup package to use generics instead of relying
on `interface{}`. Assuming that the use-case for concgroup is to always
return the same value type from `concgroup.Go` this should reduce some
boilerplate when using the library since we can avoid having to cast the
`interface{}`` values to the expected type.

This also adds two tests for the concgroup package to validate the
change and ensure that the concurrency limit is respected.
